### PR TITLE
feat: storage layer (FETCH_RECENT & FETCH_PROFILE)

### DIFF
--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,6 +1,17 @@
 import { extractMetaData } from "./steps/metaExtract";
 import { extractRawText } from "./steps/rawTextIn";
 import { extractEmbedding } from "./steps/embedding";
+import { store } from "./store"; 
+
+const userId = "demo";        // temp hard-code
+
+// ── Step 3 – FETCH_RECENT ─────────────────────────────
+const recent = store.getLastEntries(userId, 5);
+log("[FETCH_RECENT]", { recent });
+
+// ── Step 4 – FETCH_PROFILE ────────────────────────────
+let profile = store.getProfile(userId);
+log("[FETCH_PROFILE]", { profile });
 
 export function runPipeline(text: string) {
   // Step 1 - RAW_TEXT_IN - Accept the Transcript

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,0 +1,38 @@
+export interface Entry {
+  id: string;
+  rawText: string;
+  timestamp: number;
+}
+
+export interface Profile {
+  dominant_vibe: string;
+  theme_count: Record<string, number>;
+}
+
+class InMemoryStore {
+  private entries  = new Map<string, Entry[]>();
+  private profiles = new Map<string, Profile>();
+
+  getLastEntries(userId: string, k = 5): Entry[] {
+    return (this.entries.get(userId) ?? []).slice(-k).reverse();
+  }
+
+  getProfile(userId: string): Profile {
+    if (!this.profiles.has(userId)) {
+      this.profiles.set(userId, {
+        dominant_vibe: "neutral",
+        theme_count: {},
+      });
+    }
+    return this.profiles.get(userId)!;
+  }
+
+  saveEntry(userId: string, e: Entry): string {
+    const list = this.entries.get(userId) ?? [];
+    list.push(e);
+    this.entries.set(userId, list);
+    return e.id;
+  }
+}
+
+export const store = new InMemoryStore();


### PR DESCRIPTION
What’s inside
* **store.ts** – new in-memory storage module
  * `getLastEntries(userId, k)`
  * `getProfile(userId)` (auto-inits default profile)
  * `saveEntry(userId, entry)`  ← will be used in Step 10
* **pipeline.ts**
  * Added Steps **03 FETCH_RECENT** and **04 FETCH_PROFILE**
  * Uses the store helpers and logs `[FETCH_RECENT]` / `[FETCH_PROFILE]` tags
  * Temporary `log()` wrapper for JSON-pretty console output

How to test

git checkout feat/store-layer
npm run dev          # or normal simulate flow
Fixes #3
Fixes #4
