### PR TITLE
resolved lint errors: `any` types and unused vars

### DIFF
--- a/src/app/api/audio/route.ts
+++ b/src/app/api/audio/route.ts
@@ -30,7 +30,7 @@ function runPythonTranscriber(
         try {
           resolve(JSON.parse(result));
         } catch (err) {
-          reject(new Error(`Failed to parse JSON: ${result}`));
+          reject(new Error(`Error: ${err}. Failed to parse JSON: ${result}`));
         }
       }
     });
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest) {
   try {
     const { transcript } = await runPythonTranscriber(filename);
     return NextResponse.json({ transcript });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return NextResponse.json({ error: err.message }, { status: 500 });
+    }
+    return NextResponse.json({ error: 'An unknown error occurred.' }, { status: 500 });
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useRef } from "react";
+import { TranscriptResponse } from "@/lib/types";
 
 export default function Home() {
   const [recording, setRecording] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const [audioURL, setAudioURL] = useState<string | null>(null);
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<TranscriptResponse | null>(null);
 
   const startRecording = async () => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });

--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -1,6 +1,6 @@
 import { extractMetaData } from "./steps/metaExtract";
 import { extractRawText } from "./steps/rawTextIn";
-import { extractEmbedding, cosineSimilarity } from "./steps/embedding";
+import { extractEmbedding } from "./steps/embedding";
 import { updateProfile } from "./steps/profileUpdate";
 import { profileManager } from "./steps/profileManager";
 import { entryStorage } from "./steps/entryStorage";

--- a/src/core/steps/profileUpdate.ts
+++ b/src/core/steps/profileUpdate.ts
@@ -50,7 +50,7 @@ export function updateProfile(currentProfile: Profile, parsedEntry: ParsedEntry,
   // Update last theme
   updatedProfile.last_theme = [...parsedEntry.theme];
 
-  console.log(`[PROFILE_UPDATE] output=<${JSON.stringify(updatedProfile)}> | NOTE: Updated profile with new entry data.`);
+  console.log(`[PROFILE_UPDATE] output=<${JSON.stringify(updatedProfile)}, carryIn: ${carryIn}, emotional_flip: ${emotionalFlip}> | NOTE: Updated profile with new entry data.`);
   
   return updatedProfile;
 } 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,3 +47,8 @@ export type PublishedResponse = {
     response_text: string;
     carry_in: boolean;
 };
+
+// Transcript from transcribe.py
+export type TranscriptResponse = {
+    transcript: string;
+};


### PR DESCRIPTION
- `/src/app/api/audio/route.ts` - line 32 = `err` was defined, but never used | FIX: ```reject(new Error(`Error: ${err}. Failed to parse JSON: ${result}`));``` (Line 33).
- `/src/app/page.tsx` - line 9 = Unexpected `any`. Specify a different type | FIX: Made a type for our response from `transcribe.py` and used it accordingly in our front end for the result instead of `any`. 
- `/src/core/pipeline.ts` - line 3 = `cosineSimilarity` was defined but never used | FIX: Removed it since it was only needed in `carryIn.ts` and not `pipeline.ts`
- `/src/core/steps/profileUpdate.ts` - line 14 = `carryIn` and `emotionalFlip` were both params but never used | FIX: Added them to the console.log => ```console.log(`[PROFILE_UPDATE] output=<${JSON.stringify(updatedProfile)}, carryIn: ${carryIn}, emotional_flip: ${emotionalFlip}> | NOTE: Updated profile with new entry data.`);``` (Line 53).